### PR TITLE
Issue #13

### DIFF
--- a/src/client/base.rs
+++ b/src/client/base.rs
@@ -157,13 +157,13 @@ impl Client {
                             UserTypes::User => {
                                 opts_attached.header(
                                     AUTHORIZATION,
-                                    format!("User {}", user.token)
+                                    format!("{}", user.token)
                                 )
                             },
                             UserTypes::Admin => {
                                 opts_attached.header(
                                     AUTHORIZATION,
-                                    format!("Admin {}", user.token)
+                                    format!("{}", user.token)
                                 )
 
                             }

--- a/src/client/base.rs
+++ b/src/client/base.rs
@@ -22,13 +22,14 @@ impl Client {
                             UserTypes::User => {
                                 opts_attached.header(
                                     AUTHORIZATION,
-                                    format!("User {}", user.token)
+                                    format!("{}", user.token)
                                 )
                             },
                             UserTypes::Admin => {
+                                println!("Admin");
                                 opts_attached.header(
                                     AUTHORIZATION,
-                                    format!("Admin {}", user.token)
+                                    format!("{}", user.token)
                                 )
 
                             }
@@ -66,13 +67,13 @@ impl Client {
                             UserTypes::User => {
                                 req.header(
                                     AUTHORIZATION,
-                                    format!("User {}", user.token)
+                                    format!("{}", user.token)
                                 )
                             },
                             UserTypes::Admin => {
                                 req.header(
                                     AUTHORIZATION,
-                                    format!("Admin {}", user.token)
+                                    format!("{}", user.token)
                                 )
 
                             }
@@ -109,13 +110,13 @@ impl Client {
                             UserTypes::User => {
                                 req.header(
                                     AUTHORIZATION,
-                                    format!("User {}", user.token)
+                                    format!("{}", user.token)
                                 )
                             },
                             UserTypes::Admin => {
                                 req.header(
                                     AUTHORIZATION,
-                                    format!("Admin {}", user.token)
+                                    format!("{}", user.token)
                                 )
 
                             }


### PR DESCRIPTION
fixes #13 
It seems that pocket base changed token authorization.
Removed "Admin " and "User " at the base client get, post, patch and delete requests.
Now it works with admin tokens.