### PR TITLE
Replace static crud methods with ureq::agent instance

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 
 pub struct Admin<'a> {
     pub base_url: &'a str,
+    pub httpc: Httpc,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -22,7 +23,7 @@ impl<'a> Admin<'a> {
             "password": secret,
         });
         let client = Client::new(self.base_url);
-        match Httpc::post(&client, &url, credentials.to_string()) {
+        match self.httpc.post(&client, &url, credentials.to_string()) {
             Ok(response) => {
                 let raw_response = response.into_json::<AuthSuccessResponse>();
                 match raw_response {
@@ -30,6 +31,7 @@ impl<'a> Admin<'a> {
                         base_url: self.base_url.to_string(),
                         state: Auth,
                         auth_token: Some(token),
+                        httpc: self.httpc.clone(),
                     }),
                     Err(e) => Err(anyhow!("{}", e)),
                 }
@@ -39,6 +41,9 @@ impl<'a> Admin<'a> {
     }
 
     pub fn new(base_url: &'a str) -> Admin<'a> {
-        Admin { base_url }
+        Admin {
+            base_url,
+            httpc: Httpc::new(),
+        }
     }
 }

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -103,7 +103,7 @@ impl<'a> CollectionListRequestBuilder<'a> {
         build_opts.push(("per_page", per_page_opts.as_str()));
         build_opts.push(("page", page_opts.as_str()));
 
-        match Httpc::get(self.client, &url, Some(build_opts)) {
+        match self.client.httpc.get(self.client, &url, Some(build_opts)) {
             Ok(result) => {
                 let response = result.into_json::<CollectionList>()?;
                 Ok(response)
@@ -171,7 +171,7 @@ impl<'a> CollectionsManager<'a> {
 impl<'a> CollectionViewRequestBuilder<'a> {
     pub fn call(&self) -> Result<Collection> {
         let url = format!("{}/api/collections/{}", self.client.base_url, self.name);
-        match Httpc::get(self.client, &url, None) {
+        match self.client.httpc.get(self.client, &url, None) {
             Ok(result) => {
                 let response = result.into_json::<Collection>()?;
                 Ok(response)

--- a/src/httpc.rs
+++ b/src/httpc.rs
@@ -3,9 +3,18 @@ use ureq::{Request, Response};
 use crate::client::Client;
 use anyhow::Result;
 
-pub struct Httpc;
+#[derive(Debug, Clone)]
+pub struct Httpc {
+    agent: ureq::Agent,
+}
 
 impl Httpc {
+    pub fn new() -> Httpc {
+        Httpc {
+            agent: ureq::AgentBuilder::new()
+                .build(),
+        }
+    }
     fn attach_auth_info<T>(partial_request: Request, client: &Client<T>) -> Result<Request> {
         match client.auth_token.as_ref() {
             Some(token) => Ok(partial_request.set("Authorization", token)),
@@ -14,11 +23,12 @@ impl Httpc {
     }
 
     pub fn get<T>(
+        &self,
         client: &Client<T>,
         url: &str,
         query_params: Option<Vec<(&str, &str)>>,
     ) -> Result<Response> {
-        Ok(ureq::get(url))
+        Ok(self.agent.get(url))
             .and_then(|request| Self::attach_auth_info(request, client))
             .map(|request| {
                 if let Some(pairs) = query_params {
@@ -30,21 +40,26 @@ impl Httpc {
             .and_then(|request| Ok(request.call()?))
     }
 
-    pub fn post<T>(client: &Client<T>, url: &str, body_content: String) -> Result<Response> {
-        Ok(ureq::post(url))
+    pub fn post<T>(&self, client: &Client<T>, url: &str, body_content: String) -> Result<Response> {
+        Ok(self.agent.post(url))
             .map(|request| request.set("Content-Type", "application/json"))
             .and_then(|request| Self::attach_auth_info(request, client))
             .and_then(|request| Ok(request.send_string(body_content.as_str())?))
     }
 
-    pub fn delete<T>(client: &Client<T>, url: &str) -> Result<Response> {
-        Ok(ureq::delete(url))
+    pub fn delete<T>(&self, client: &Client<T>, url: &str) -> Result<Response> {
+        Ok(self.agent.delete(url))
             .and_then(|request| Self::attach_auth_info(request, client))
             .and_then(|request| Ok(request.call()?))
     }
 
-    pub fn patch<T>(client: &Client<T>, url: &str, body_content: String) -> Result<Response> {
-        Ok(ureq::patch(url))
+    pub fn patch<T>(
+        &self,
+        client: &Client<T>,
+        url: &str,
+        body_content: String,
+    ) -> Result<Response> {
+        Ok(self.agent.patch(url))
             .map(|request| request.set("Content-Type", "application/json"))
             .and_then(|request| Self::attach_auth_info(request, client))
             .and_then(|request| Ok(request.send_string(body_content.as_str())?))

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -75,7 +75,7 @@ impl<'a> LogStatisticsRequestBuilder<'a> {
             build_opts.push(("filter", filter_opts.to_owned()));
         }
 
-        match Httpc::get(self.client, &url, Some(build_opts)) {
+        match self.client.httpc.get(self.client, &url, Some(build_opts)) {
             Ok(result) => {
                 let response = result.into_json::<Vec<LogStatDataPoint>>()?;
                 Ok(response)
@@ -88,7 +88,7 @@ impl<'a> LogStatisticsRequestBuilder<'a> {
 impl<'a> LogViewRequestBuilder<'a> {
     pub fn call(&self) -> Result<LogListItem> {
         let url = format!("{}/api/logs/requests/{}", self.client.base_url, self.id);
-        match Httpc::get(self.client, &url, None) {
+        match self.client.httpc.get(self.client, &url, None) {
             Ok(result) => {
                 let response = result.into_json::<LogListItem>()?;
                 Ok(response)
@@ -138,7 +138,7 @@ impl<'a> LogListRequestBuilder<'a> {
         build_opts.push(("per_page", per_page_opts.as_str()));
         build_opts.push(("page", page_opts.as_str()));
 
-        match Httpc::get(self.client, &url, Some(build_opts)) {
+        match self.client.httpc.get(self.client, &url, Some(build_opts)) {
             Ok(result) => {
                 let response = result.into_json::<LogList>()?;
                 Ok(response)

--- a/src/records.rs
+++ b/src/records.rs
@@ -48,7 +48,7 @@ impl<'a> RecordsListRequestBuilder<'a> {
         build_opts.push(("per_page", per_page_opts.as_str()));
         build_opts.push(("page", page_opts.as_str()));
 
-        match Httpc::get(self.client, &url, Some(build_opts)) {
+        match self.client.httpc.get(self.client, &url, Some(build_opts)) {
             Ok(result) => {
                 let response = result.into_json::<RecordList<T>>()?;
                 Ok(response)
@@ -98,7 +98,7 @@ impl<'a> RecordViewRequestBuilder<'a> {
             "{}/api/collections/{}/records/{}",
             self.client.base_url, self.collection_name, self.identifier
         );
-        match Httpc::get(self.client, &url, None) {
+        match self.client.httpc.get(self.client, &url, None) {
             Ok(result) => {
                 let response = result.into_json::<T>()?;
                 Ok(response)
@@ -114,7 +114,7 @@ impl<'a> RecordDestroyRequestBuilder<'a> {
             "{}/api/collections/{}/records/{}",
             self.client.base_url, self.collection_name, self.identifier
         );
-        match Httpc::delete(self.client, url.as_str()) {
+        match self.client.httpc.delete(self.client, url.as_str()) {
             Ok(result) => {
                 if result.status() == 204 {
                     Ok(())
@@ -166,7 +166,7 @@ impl<'a, T: Serialize + Clone> RecordCreateRequestBuilder<'a, T> {
             self.client.base_url, self.collection_name
         );
         let payload = serde_json::to_string(&self.record).map_err(anyhow::Error::from)?;
-        match Httpc::post(self.client, &url, payload) {
+        match self.client.httpc.post(self.client, &url, payload) {
             Ok(result) => {
                 let response = result.into_json::<CreateResponse>()?;
                 Ok(response)
@@ -190,7 +190,7 @@ impl<'a, T: Serialize + Clone> RecordUpdateRequestBuilder<'a, T> {
             self.client.base_url, self.collection_name, self.id
         );
         let payload = serde_json::to_string(&self.record).map_err(anyhow::Error::from)?;
-        match Httpc::patch(self.client, &url, payload) {
+        match self.client.httpc.patch(self.client, &url, payload) {
             Ok(result) => {
                 result.into_json::<CreateResponse>()?;
                 Ok(self.record.clone())


### PR DESCRIPTION
Hello, 
Thanks for making this lib!
I ran into an issue while trying to "bulk" create records in a loop, it was taking 2 seconds! per record to insert.

I traced the slowness to the records.create()**.call()** method and finally to the 
`request.send_string(body_content.as_str()` line inside Httpc's post method.

I believe the issue may be caused by the instantiation of ureq on each request. 

while testing using an instance of ureq (ureq::Agent) I now see expected results of 2ms/rec.

I've made this quick and dirty PR to illustrate.