### PR TITLE
per_page to perPage to fix pagination

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -45,7 +45,7 @@ impl<'a> RecordsListRequestBuilder<'a> {
         }
         let per_page_opts = self.per_page.to_string();
         let page_opts = self.page.to_string();
-        build_opts.push(("per_page", per_page_opts.as_str()));
+        build_opts.push(("perPage", per_page_opts.as_str()));
         build_opts.push(("page", page_opts.as_str()));
 
         match Httpc::get(self.client, &url, Some(build_opts)) {


### PR DESCRIPTION
Cool library and thanks for making sure it doesn't break. It's very useful while creating my own software with it. 

A minor issue I found was that the parameter "per_page" is an invalid parameter and will be ignored which is unintended. Instead of giving our expected items per page, we'll get the default items per page which is 30. 

In order to fix this, simply make the request align with the [PocketBase API list documentation](https://pocketbase.io/docs/api-logs#list-logs) and show the correct parameter name "perPage" instead.
